### PR TITLE
ci: Add Docker build step to CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -56,6 +56,18 @@ jobs:
     - name: Run health check
       run: python health_check.py
 
+  docker-build:
+    # Build runs only if tests pass
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build Docker image
+        # Builds the image to ensure the Dockerfile is valid
+        run: docker build . --file Dockerfile --tag my-app:$(date +%s)
+
   # Job 2: Build and deploy documentation
   build-and-deploy-docs:
     # This job runs only after the 'test' job has successfully completed


### PR DESCRIPTION
This task involves modifying the existing GitHub Actions workflow to include a job that attempts to build the Docker image defined in the previous task. This acts as a quality gate to prevent code that breaks containerization from reaching production.

closes #46